### PR TITLE
ajout d'un workflow github (mise à jour winget)

### DIFF
--- a/.github/workflows/winget.yaml
+++ b/.github/workflows/winget.yaml
@@ -1,0 +1,22 @@
+name: Mise à jour sur Winget 
+
+on:
+  release:
+    types: [published]
+
+env:
+  packageFileName: Installer.exe
+  packageId: STYInc.STY1001.UnowhyTools
+  
+jobs:
+  
+  winget:
+    name: Publication sur Winget
+    runs-on: windows-latest
+    steps:
+      - name: Envoi à Github
+        run: |
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
+          $installerUrl = $github.release.assets | Where-Object -Property name -match ${env:packageFileName} | Select -ExpandProperty browser_download_url -First 1
+          .\wingetcreate.exe update ${env:packageId} -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.Project_PAT }}


### PR DESCRIPTION
Salut ! 
Je te passe cet action Github qui va automatiquement mettre à jour sur Winget le manifest d'Unowhy Tools.

La seule chose que tu dois faire est d'ajouter un token dans les variables secrètes du repo en tant que "Project_PAT" (soit tu te créé un token, soit je te passe le mien en message privé).

A chaque fois que tu feras une release GitHub, elle sera automatiquement envoyée à Microsoft ;)

![image](https://github-production-user-asset-6210df.s3.amazonaws.com/50982832/293284019-7b710e6b-6b6c-4823-8811-77fd884b7d61.png)


