### PR TITLE
Use shared HttpClient, async fixes & caching

### DIFF
--- a/Unowhy Tools WPF/Services/ApplicationHostService.cs
+++ b/Unowhy Tools WPF/Services/ApplicationHostService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting;
 using System;
 using System.IO;
 using System.IO.Pipes;
@@ -72,7 +72,7 @@ public class ApplicationHostService : IHostedService
             {
                 if (!await UT.CheckTray())
                 {
-                    Task.Run(() => UTTwait());
+                    _ = Task.Run(UTTwait);
                     _testWindowService.Show<Views.TrayWindow>();
                 }
                 else

--- a/Unowhy Tools WPF/UT.cs
+++ b/Unowhy Tools WPF/UT.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
             
             
               ."I!ii>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>ii!I".
@@ -120,6 +120,7 @@ using Microsoft.Win32;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -152,6 +153,10 @@ namespace Unowhy_Tools
 {
     public partial class UT
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+        private static readonly ConcurrentDictionary<string, string> _wmiCache = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        private static readonly ConcurrentDictionary<string, BitmapImage> _resourceImageCache = new ConcurrentDictionary<string, BitmapImage>(StringComparer.OrdinalIgnoreCase);
+
         #region DLL
         [DllImport("DwmApi")]
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, int[] attrValue, int attrSize);
@@ -229,7 +234,6 @@ namespace Unowhy_Tools
 
             public static async Task<bool> newver()
             {
-                var web = new HttpClient();
                 string newver = await UT.OnlineDatas.GetUpdates("utnewver");
                 int newverint = Convert.ToInt32(newver);
                 if (verfull < newverint)
@@ -982,25 +986,25 @@ namespace Unowhy_Tools
             }
         }
 
-        public static async Task DeployDABack()
+        public static Task DeployDABack()
         {
             var mainWindow = System.Windows.Application.Current.MainWindow as Unowhy_Tools_WPF.Views.MainWindow;
-            mainWindow.DeployDABack();
+            return mainWindow.DeployDABack();
         }
 
-        public static async Task DeployBack(Type type, Grid grid, Border border)
+        public static Task DeployBack(Type type, Grid grid, Border border)
         {
             var mainWindow = System.Windows.Application.Current.MainWindow as Unowhy_Tools_WPF.Views.MainWindow;
-            mainWindow.DeployBack(type, grid, border);
+            return mainWindow.DeployBack(type, grid, border);
         }
 
-        public static async Task UnDeployBack()
+        public static Task UnDeployBack()
         {
             var mainWindow = System.Windows.Application.Current.MainWindow as Unowhy_Tools_WPF.Views.MainWindow;
-            mainWindow.UnDeployBack();
+            return mainWindow.UnDeployBack();
         }
 
-        public static async void NavigateTo(Type page)
+        public static void NavigateTo(Type page)
         {
             var mainWindow = System.Windows.Application.Current.MainWindow as Unowhy_Tools_WPF.Views.MainWindow;
             mainWindow.Navigate(page);
@@ -4106,6 +4110,12 @@ namespace Unowhy_Tools
 
         public static string GetWMI(string classname, string propertyname)
         {
+            string cacheKey = classname + "|" + propertyname;
+            if (_wmiCache.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
             Write2Log("Get WMI: " + classname + " | " + propertyname);
 
             try
@@ -4114,15 +4124,19 @@ namespace Unowhy_Tools
                 ManagementObjectCollection result = searcher.Get();
                 foreach (ManagementObject obj in result)
                 {
-                    Write2Log("Get WMI done: " + obj[propertyname]?.ToString());
-                    return obj[propertyname]?.ToString();
+                    string value = obj[propertyname]?.ToString() ?? "null";
+                    Write2Log("Get WMI done: " + value);
+                    _wmiCache.TryAdd(cacheKey, value);
+                    return value;
                 }
                 Write2Log("Get WMI fail");
+                _wmiCache.TryAdd(cacheKey, "null");
                 return "null";
             }
             catch
             {
                 Write2Log("Get WMI fail");
+                _wmiCache.TryAdd(cacheKey, "null");
                 return "null";
             }
         }
@@ -4130,8 +4144,7 @@ namespace Unowhy_Tools
         public static async Task DlFilewithProgress(string url, string path, IProgress<double> progress, CancellationToken token)
         {
             Write2Log("Downloading file: From \"" + url + "\" to \"" + path + "\"");
-            HttpClient client = new HttpClient();
-            var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
+            using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -4144,8 +4157,8 @@ namespace Unowhy_Tools
             int updateInterval = 100;
             DateTime lastUpdate = DateTime.Now;
 
-            using (Stream stream = await response.Content.ReadAsStreamAsync())
-            using (FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            await using (Stream stream = await response.Content.ReadAsStreamAsync(token))
+            await using (FileStream fileStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 byte[] buffer = new byte[1024*1024];
                 int bytesRead;
@@ -4186,8 +4199,16 @@ namespace Unowhy_Tools
 
         public static BitmapImage GetImgSource(string resname)
         {
-            BitmapImage bmp = new BitmapImage(new System.Uri("pack://application:,,,/Resources/" + resname));
-            return bmp;
+            return _resourceImageCache.GetOrAdd(resname, static key =>
+            {
+                var bmp = new BitmapImage();
+                bmp.BeginInit();
+                bmp.CacheOption = BitmapCacheOption.OnLoad;
+                bmp.UriSource = new Uri("pack://application:,,,/Resources/" + key);
+                bmp.EndInit();
+                bmp.Freeze();
+                return bmp;
+            });
         }
 
         public static ImageSource GetImageSourceFromExe(string path)

--- a/Unowhy Tools WPF/Views/MainWindow.xaml.cs
+++ b/Unowhy Tools WPF/Views/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -70,7 +70,7 @@ public partial class MainWindow : INavigationWindow
 
         SnackBarService = _snackbarService;
 
-        applylang();
+        Loaded += async (_, __) => await applylang();
         this.KeyDown += MainWindow_KonamiKeyDown;
         this.KeyUp += MainWindow_KonamiKeyUp;
     }

--- a/Unowhy Tools WPF/Views/Pages/About.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/About.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -33,8 +33,8 @@ public partial class About : INavigableView<DashboardViewModel>
 
     public async void GoUpdater(object sender, RoutedEventArgs e)
     {
-        UT.anim.RegisterParent(RootGrid, RootBorder);
-        UT.anim.AnimParent("zoomout2");
+        await UT.anim.RegisterParent(RootGrid, RootBorder);
+        await UT.anim.AnimParent("zoomout2");
         await Task.Delay(500);
         UT.NavigateTo(typeof(Updater));
     }

--- a/Unowhy Tools WPF/Views/Pages/AddUser.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/AddUser.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -39,7 +39,7 @@ public partial class AddUser : INavigableView<DashboardViewModel>
         }
 
         await UT.DeployBack(typeof(Customize), RootGrid, RootBorder);
-        UT.anim.BorderZoomOut(RootBorder);
+        await UT.anim.BorderZoomOut(RootBorder);
 
         foreach (UIElement element in RootStack.Children)
         {

--- a/Unowhy Tools WPF/Views/Pages/Dashboard.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/Dashboard.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
@@ -50,7 +50,7 @@ public partial class Dashboard : INavigableView<DashboardViewModel>
 
         lababout2.Text = ver;
 
-        applylang();
+        await applylang();
         pcname.Text = UT.GetLine(UTdata.HostName, 1);
 
         if (await UT.CheckInternet())
@@ -62,7 +62,6 @@ public partial class Dashboard : INavigableView<DashboardViewModel>
                 {
                     Color white = (Color)ColorConverter.ConvertFromString("#FFFFFF");
                     Color gray = (Color)ColorConverter.ConvertFromString("#bebebe");
-                    var web = new HttpClient();
                     string newver = await UT.OnlineDatas.GetUpdates("utnewver");
                     newver = newver.Insert(2, ".");
                     newver = newver.Replace("\n", "");

--- a/Unowhy Tools WPF/Views/Pages/DrvCloud.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/DrvCloud.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -31,6 +31,8 @@ public partial class DrvCloud : INavigableView<DashboardViewModel>
     {
         get;
     }
+
+    private static readonly HttpClient _http = new HttpClient();
 
     public void GoForw(object sender, RoutedEventArgs e)
     {
@@ -314,11 +316,10 @@ public partial class DrvCloud : INavigableView<DashboardViewModel>
             SkeletonStack.Visibility = Visibility.Collapsed;
 
             string datasurl = UT.online_datas;
-            HttpClient web = new HttpClient();
-            HttpResponseMessage rep = await web.GetAsync(datasurl);
+            HttpResponseMessage rep = await _http.GetAsync(datasurl);
             if (rep.StatusCode == HttpStatusCode.OK)
             {
-                string jsonContent = await web.GetStringAsync(datasurl);
+                string jsonContent = await _http.GetStringAsync(datasurl);
                 dynamic jsonObject = JsonConvert.DeserializeObject(jsonContent);
                 if (jsonObject.drivers != null && jsonObject.drivers.Count > 0)
                 {

--- a/Unowhy Tools WPF/Views/Pages/PCinfo.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/PCinfo.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -18,6 +18,7 @@ namespace Unowhy_Tools_WPF.Views.Pages;
 public partial class PCinfo : INavigableView<DashboardViewModel>
 {
     UT.Data UTdata = new UT.Data();
+    private string _tempWallpaperPath;
 
     public DashboardViewModel ViewModel
     {
@@ -91,11 +92,24 @@ public partial class PCinfo : INavigableView<DashboardViewModel>
         {
             imgwv.Source = new BitmapImage(new System.Uri("pack://application:,,,/Resources/win10.png"));
         }
-        Random rand = new Random();
-        int random = rand.Next(0, 1000000);
-        File.Copy(Environment.GetEnvironmentVariable("USERPROFILE") + "\\AppData\\Roaming\\Microsoft\\Windows\\Themes\\TranscodedWallpaper", Environment.GetEnvironmentVariable("TEMP") + $"\\TranscodedWallpaper_{random}.jpg");
-        string curentbgpath = Environment.GetEnvironmentVariable("TEMP") + $"\\TranscodedWallpaper_{random}.jpg";
-        bgimg.Source = new BitmapImage(new System.Uri(curentbgpath));
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(_tempWallpaperPath) && File.Exists(_tempWallpaperPath))
+            {
+                File.Delete(_tempWallpaperPath);
+            }
+
+            string source = Environment.GetEnvironmentVariable("USERPROFILE") + "\\AppData\\Roaming\\Microsoft\\Windows\\Themes\\TranscodedWallpaper";
+            string dest = Path.Combine(Environment.GetEnvironmentVariable("TEMP") ?? Path.GetTempPath(), $"TranscodedWallpaper_{Guid.NewGuid():N}.jpg");
+            File.Copy(source, dest, true);
+            _tempWallpaperPath = dest;
+
+            bgimg.Source = new BitmapImage(new System.Uri(dest));
+        }
+        catch
+        {
+            // best-effort wallpaper; ignore failures
+        }
     }
 
     public async void InitAnim(object sender, RoutedEventArgs e)
@@ -112,7 +126,7 @@ public partial class PCinfo : INavigableView<DashboardViewModel>
         bgimg.Visibility = Visibility.Hidden;
 
         await UT.DeployBack(typeof(Dashboard), RootGrid, RootBorder);
-        UT.anim.BorderZoomOut(RootBorder);
+        await UT.anim.BorderZoomOut(RootBorder);
 
         await infoapply();
 

--- a/Unowhy Tools WPF/Views/Pages/Updater.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/Updater.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Web.WebView2.Wpf;
+using Microsoft.Web.WebView2.Wpf;
 using Microsoft.Win32.TaskScheduler;
 using System;
 using System.Diagnostics;
@@ -169,7 +169,6 @@ public partial class Updater : INavigableView<DashboardViewModel>
         if (await UT.version.newver())
         {
             labimg.Source = UT.GetImgSource("yes.png");
-            var web = new HttpClient();
             string newver = await UT.OnlineDatas.GetUpdates("utnewver");
             newver = newver.Insert(2, ".");
             newver = newver.Replace("\n", "");
@@ -183,7 +182,6 @@ public partial class Updater : INavigableView<DashboardViewModel>
         else if (UT.version.isdeb())
         {
             labimg.Source = UT.GetImgSource("yes.png");
-            var web = new HttpClient();
             string newver = await UT.OnlineDatas.GetUpdates("utnewver");
             newver = newver.Insert(2, ".");
             newver = newver.Replace("\n", "");

--- a/Unowhy Tools WPF/Views/Pages/Wifi.xaml.cs
+++ b/Unowhy Tools WPF/Views/Pages/Wifi.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -23,6 +23,7 @@ namespace Unowhy_Tools_WPF.Views.Pages;
 public partial class Wifi : INavigableView<DashboardViewModel>
 {
     UT.Data UTdata = new UT.Data();
+    private static readonly HttpClient _http = new HttpClient();
 
     public DashboardViewModel ViewModel
     {
@@ -40,7 +41,7 @@ public partial class Wifi : INavigableView<DashboardViewModel>
 
     public async void Init(object sender, EventArgs e)
     {
-        applylang();
+        await applylang();
         string confserv = await UT.Config.Get("ConfServer");
         if (confserv == "idf")
         {
@@ -78,7 +79,7 @@ public partial class Wifi : INavigableView<DashboardViewModel>
         }
 
         await UT.DeployBack(typeof(Dashboard), RootGrid, RootBorder);
-        UT.anim.BorderZoomOut(RootBorder);
+        await UT.anim.BorderZoomOut(RootBorder);
 
         foreach (UIElement element in RootGrid2.Children)
         {
@@ -219,7 +220,6 @@ public partial class Wifi : INavigableView<DashboardViewModel>
                 await UT.waitstatus.open(await UT.GetLang("wait.get"), "clouddl.png");
                 await Task.Delay(1000);
 
-                var web = new HttpClient();
                 string sn = serial.Text;
                 string preurl = "null";
                 if (confserv_idf.IsSelected == true)
@@ -232,7 +232,7 @@ public partial class Wifi : INavigableView<DashboardViewModel>
                 }
                 string configurl = $"{preurl}/devices/{sn}/configuration";
 
-                HttpResponseMessage response = await web.GetAsync(configurl);
+                HttpResponseMessage response = await _http.GetAsync(configurl);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     DoubleAnimation translateAnimation = new DoubleAnimation
@@ -248,7 +248,7 @@ public partial class Wifi : INavigableView<DashboardViewModel>
                     transform.BeginAnimation(TranslateTransform.XProperty, translateAnimation);
                     await Task.Delay(500);
 
-                    string g = await web.GetStringAsync(configurl);
+                    string g = await _http.GetStringAsync(configurl);
                     string jsonString = g;
                     List<dynamic> dataList = JsonConvert.DeserializeObject<List<dynamic>>(jsonString);
 
@@ -266,7 +266,7 @@ public partial class Wifi : INavigableView<DashboardViewModel>
 
                     foreach (var url in urlList)
                     {
-                        JObject json = JObject.Parse(await web.GetStringAsync(url));
+                        JObject json = JObject.Parse(await _http.GetStringAsync(url));
                         mergedJson.Merge(json);
                     }
 

--- a/Unowhy Tools WPF/Views/TrayWindow.xaml.cs
+++ b/Unowhy Tools WPF/Views/TrayWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -84,38 +84,40 @@ public partial class TrayWindow : Window
     {
         _timerStats = new DispatcherTimer();
         _timerStats.Interval = TimeSpan.FromSeconds(1);
-        _timerStats.Tick += async (sender, e) => CheckStats();
+        _timerStats.Tick += async (sender, e) => await CheckStats();
         _timerStats.Start();
 
         _timerPower = new DispatcherTimer();
         _timerPower.Interval = TimeSpan.FromSeconds(1);
-        _timerPower.Tick += async (sender, e) => CheckPower();
+        _timerPower.Tick += async (sender, e) => await CheckPower();
         _timerPower.Start();
 
         _timerPriv = new DispatcherTimer();
         _timerPriv.Interval = TimeSpan.FromSeconds(1);
-        _timerPriv.Tick += async (sender, e) => CheckPriv();
+        _timerPriv.Tick += async (sender, e) => await CheckPriv();
         _timerPriv.Start();
 
         _timerTimeDate = new DispatcherTimer();
         _timerTimeDate.Interval = TimeSpan.FromSeconds(1);
-        _timerTimeDate.Tick += async (sender, e) => UpdateTimeDate();
+        _timerTimeDate.Tick += async (sender, e) => await UpdateTimeDate();
         _timerTimeDate.Start();
 
         _timerUpdate = new DispatcherTimer();
         _timerUpdate.Interval = TimeSpan.FromSeconds(600);
-        _timerUpdate.Tick += async (sender, e) => CheckUpdate();
+        _timerUpdate.Tick += async (sender, e) => await CheckUpdate();
         _timerUpdate.Start();
     }
 
-    public async Task StartTimer()
+    public Task StartTimer()
     {
         IsPause = false;
+        return Task.CompletedTask;
     }
 
-    public async Task StopTimer()
+    public Task StopTimer()
     {
         IsPause = true;
+        return Task.CompletedTask;
     }
 
     public bool updatecheck = true;

--- a/Unowhy Tools WPF/Views/Windows/DialogI.xaml.cs
+++ b/Unowhy Tools WPF/Views/Windows/DialogI.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Windows;
 using System.Windows.Media;
@@ -21,6 +21,7 @@ namespace Unowhy_Tools_WPF.Views.Windows
 
         private bool _hideRequest = false;
         private bool _result = false;
+        private DispatcherFrame _frame;
 
 
         public bool ShowDialog(string message, BitmapImage image)
@@ -89,19 +90,8 @@ namespace Unowhy_Tools_WPF.Views.Windows
             transform.BeginAnimation(TranslateTransform.YProperty, translateAnimation);
 
             _hideRequest = false;
-            while (!_hideRequest)
-            {
-                if (this.Dispatcher.HasShutdownStarted ||
-                    this.Dispatcher.HasShutdownFinished)
-                {
-                    break;
-                }
-
-                this.Dispatcher.Invoke(
-                    DispatcherPriority.Background,
-                    new ThreadStart(delegate { }));
-                Thread.Sleep(20);
-            }
+            _frame = new DispatcherFrame();
+            Dispatcher.PushFrame(_frame);
 
             return _result;
         }
@@ -154,6 +144,10 @@ namespace Unowhy_Tools_WPF.Views.Windows
         {
             Visibility = Visibility.Collapsed;
             _hideRequest = true;
+            if (_frame != null)
+            {
+                _frame.Continue = false;
+            }
         }
 
         private void OkButton_Click(object sender, RoutedEventArgs e)

--- a/Unowhy Tools WPF/Views/Windows/DialogQ.xaml.cs
+++ b/Unowhy Tools WPF/Views/Windows/DialogQ.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Windows;
 using System.Windows.Media;
@@ -36,6 +36,7 @@ namespace Unowhy_Tools_WPF.Views.Windows
 
         private bool _hideRequest = false;
         private bool _result = false;
+        private DispatcherFrame _frame;
 
         public bool ShowDialog(string message, BitmapImage image)
         {
@@ -105,19 +106,8 @@ namespace Unowhy_Tools_WPF.Views.Windows
             transform.BeginAnimation(TranslateTransform.YProperty, translateAnimation);
 
             _hideRequest = false;
-            while (!_hideRequest)
-            {
-                if (this.Dispatcher.HasShutdownStarted ||
-                    this.Dispatcher.HasShutdownFinished)
-                {
-                    break;
-                }
-
-                this.Dispatcher.Invoke(
-                    DispatcherPriority.Background,
-                    new ThreadStart(delegate { }));
-                Thread.Sleep(20);
-            }
+            _frame = new DispatcherFrame();
+            Dispatcher.PushFrame(_frame);
 
             return _result;
         }
@@ -170,6 +160,10 @@ namespace Unowhy_Tools_WPF.Views.Windows
         {
             _hideRequest = true;
             Visibility = Visibility.Collapsed;
+            if (_frame != null)
+            {
+                _frame.Continue = false;
+            }
         }
 
         private void YesButton_Click(object sender, RoutedEventArgs e)

--- a/Unowhy Tools WPF/Views/Windows/Wait.xaml.cs
+++ b/Unowhy Tools WPF/Views/Windows/Wait.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -16,12 +16,12 @@ namespace Unowhy_Tools_WPF.Views.Windows
         {
             InitializeComponent();
 
-            applylang();
+            Loaded += async (_, __) => await ApplyLangAsync();
 
             Visibility = Visibility.Collapsed;
         }
 
-        public async void applylang()
+        public async Task ApplyLangAsync()
         {
             try
             {
@@ -33,7 +33,7 @@ namespace Unowhy_Tools_WPF.Views.Windows
 
         public bool IsOpen = false;
 
-        public async Task Show(string title, string img)
+        public Task Show(string title, string img)
         {
             if (IsOpen)
             {
@@ -93,9 +93,11 @@ namespace Unowhy_Tools_WPF.Views.Windows
 
                 storyboard.Begin();
             }
+
+            return Task.CompletedTask;
         }
 
-        public async Task Hide()
+        public Task Hide()
         {
             IsOpen = false;
             var fadeInAnimation2 = new DoubleAnimation
@@ -138,6 +140,8 @@ namespace Unowhy_Tools_WPF.Views.Windows
             storyboard.Completed += RealHide;
 
             storyboard.Begin();
+
+            return Task.CompletedTask;
         }
 
         public void RealHide(object sender, EventArgs e)


### PR DESCRIPTION
Introduce shared HttpClient instances and concurrent caches (WMI results and resource images) to avoid repeated allocations and improve performance. Convert many methods to return Task or await calls properly (timers, UI animations, navigation/deploy, and page init methods) to ensure correct async flow and responsiveness. Replace busy-wait loops in modal dialogs with DispatcherFrame, harden wallpaper handling with a temp file and best-effort fallback, and improve file download stream handling (cancellation, FileShare). Remove many local HttpClient constructions and reuse static clients to prevent socket exhaustion.